### PR TITLE
feat: Support Google Blockly theme

### DIFF
--- a/projects/ngx-blockly/README.md
+++ b/projects/ngx-blockly/README.md
@@ -255,6 +255,49 @@ export class TestBlock extends CustomBlock {
 }
 ```
 
+### Theme
+Customized theme can be specified in the `theme` option for `NgxBlocklyConfig`, and the format of the block style and category style is stated in the [Themes](https://developers.google.com/blockly/guides/configure/web/themes).
 
+Sample theme class (Using Google Blockly [Classic theme](https://github.com/google/blockly/blob/master/core/theme/classic.js)):
+```typescript
+export const blockStyles: BlockStyles = {
+  logic_blocks: {
+    colourPrimary: '210',
+  },
+};
 
+export const categoryStyles: CategoryStyles = {
+  logic_category: {
+    colour: '210',
+  },
+}
 
+export const ClassicTheme: Theme = new Theme (
+  blockStyles,
+  categoryStyles
+)
+```
+
+When you have specified the theme used in Blockly workspace, you need to declare the corresponding block style/category style in block/category definition. Noted that once you have defined the theme option in `NgxBlocklyConfig`, then you need to manage color scheme of all blocks and categories.
+
+Block Styling
+```typescript
+{
+  "type": "controls_if",
+  "style": "logic_blocks", // Specify the block style to apply
+}
+```
+
+Category Styling
+```xml
+<!-- Specify the category style to apply -->
+<category name="Logic" categorystyle="logic_category">
+</category>
+```
+
+Corresponding NgxBlocklyConfig
+```typescript
+config: NgxBlocklyConfig = {
+    theme: ClassicTheme.createBlocklyTheme(),
+  };
+```

--- a/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
@@ -6,12 +6,20 @@ export class Category {
     private _colour: string;
     private _name: string;
     private _custom: string;
+    private _style: string;
 
-    constructor(blocks: Block[], colour: string, name: string, custom: string) {
+    constructor(
+        blocks: Block[], 
+        colour: string, 
+        name: string, 
+        custom: string, 
+        style?: string
+    ) {
         this._blocks = blocks;
         this._colour = colour;
         this._name = name;
         this._custom = custom;
+        this._style = style;
     }
 
     get blocks(): Block[] {
@@ -46,8 +54,23 @@ export class Category {
         this._custom = value;
     }
 
+    get style(): string {
+        return this._style;
+    }
+
+    set style(value: string) {
+        this._style = value;
+    }
+
     public toXML(): string {
-        let xml = `<category name="${this.name}" colour="${this.colour}"`;
+        let xml = `<category name="${this.name}" `;
+
+        if (this.style === undefined) {
+            xml += `colour="${this.colour}" `
+        } else {
+            xml += `categorystyle="${this.style}" `
+        }
+
         xml += this.custom ? ` custom="${this.custom}">` : '>';
         for (const block of this.blocks) {
             xml += block.toXML();

--- a/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
@@ -66,9 +66,9 @@ export class Category {
         let xml = `<category name="${this.name}" `;
 
         if (this.style === undefined) {
-            xml += `colour="${this.colour}" `
+            xml += `colour="${this.colour}" `;
         } else {
-            xml += `categorystyle="${this.style}" `
+            xml += `categorystyle="${this.style}" `;
         }
 
         xml += this.custom ? ` custom="${this.custom}">` : '>';

--- a/projects/ngx-blockly/src/lib/ngx-blockly/models/theme.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/models/theme.ts
@@ -1,0 +1,32 @@
+declare var Blockly: any;
+
+export class Theme {
+  constructor(
+    private blockStyles: BlockStyles,
+    private categoryStyles: CategoryStyles
+  ) {
+  }
+
+  createBlocklyTheme(): any {
+    return new Blockly.Theme(this.blockStyles, this.categoryStyles);
+  }
+}
+
+export interface BlockStyles {
+  [blockStyleName: string]: BlockStyle;
+}
+
+export interface CategoryStyles {
+  [categoryStyleName: string]: CategoryStyle;
+}
+
+export class BlockStyle {
+  colourPrimary: string;
+  colourSecondary?: string;
+  colourTertiary?: string;
+  hat?: string;
+}
+
+export class CategoryStyle {
+  colour: string;
+}


### PR DESCRIPTION
According to the update of Google Blockly in April 2019, themes provide 
a customized way to define look and feel for blocks and categories.
Thus, this commit add support to the block and category styles.

Reference: https://developers.google.com/blockly/guides/configure/web/themes