### PR TITLE
Remove the passing of this to the custom block constructor

### DIFF
--- a/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
@@ -40,7 +40,7 @@ export class NgxBlocklyComponent implements OnInit, AfterViewInit, OnChanges, On
             for (const customBlock of this.customBlocks) {
                 Blockly.Blocks[customBlock.type] = {
                     init: function () {
-                        const block = new customBlock.class(customBlock.type, this, customBlock.blockMutator, ...customBlock.args);
+                        const block = new customBlock.class(customBlock.type, customBlock.blockMutator, ...customBlock.args);
                         block.init(this);
                         this.mixin({
                                 blockInstance: block


### PR DESCRIPTION
Because you removed the block argument from the constructor. Leaving this as it is, it would conflict with the ...args argument.