### PR TITLE
Switch compilation to partial ivy.

### DIFF
--- a/projects/ngx-blockly/tsconfig.lib.prod.json
+++ b/projects/ngx-blockly/tsconfig.lib.prod.json
@@ -1,6 +1,6 @@
 {
   "extends": "./tsconfig.lib.json",
   "angularCompilerOptions": {
-    "enableIvy": false
+    "compilationMode": "partial"
   }
 }


### PR DESCRIPTION
The current configuration disables ivy compilation.
https://github.com/roroettg/ngx-blockly/blob/master/projects/ngx-blockly/tsconfig.lib.prod.json#L4
The recommended for angular v12 is switching it to partial ivy.
https://angular.io/guide/creating-libraries#building-libraries-with-ivy