### PR TITLE
Enable ivy, remove duplicat create list with block.

### DIFF
--- a/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/models/category.ts
@@ -176,7 +176,6 @@ export const TEXT_CATEGORY: Category = new Category('Text', '%{BKY_TEXTS_HUE}', 
 
 export const LISTS_CATEGORY: Category = new Category('Lists', '%{BKY_LISTS_HUE}', [
     new XmlBlock('lists_create_with'),
-    new XmlBlock('lists_create_with'),
     new XmlBlock('lists_repeat'),
     new XmlBlock('lists_length'),
     new XmlBlock('lists_isEmpty'),

--- a/projects/ngx-blockly/tsconfig.lib.json
+++ b/projects/ngx-blockly/tsconfig.lib.json
@@ -23,7 +23,7 @@
     "fullTemplateTypeCheck": true,
     "strictInjectionParameters": true,
     "enableResourceInlining": true,
-    "enableIvy": false
+    "enableIvy": true
   },
   "exclude": [
     "src/test.ts",


### PR DESCRIPTION
Previous pull request switched compliation to ivy, but got overwritten by the regular config. Regular config now also enables ivy.