### PR TITLE
Fix for readonly issue

### DIFF
--- a/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
@@ -130,11 +130,14 @@ export class NgxBlocklyComponent implements OnInit, AfterViewInit, OnChanges, On
         this.workspace = Blockly.inject(this.primaryContainer.nativeElement, this.config);
         this.workspace.addChangeListener(this._onWorkspaceChange.bind(this));
         this.workspaceCreate.emit(this.workspace);
+        if (this.readonly)
+          this.setReadonly(this.readonly);
         this.resize();
     }
 
     ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
-        if (changes.readonly) {
+        //skip this if the change comes before we are initialized
+        if (changes.readonly && this._secondaryWorkspace) {
             this.setReadonly(changes.readonly.currentValue);
         }
     }


### PR DESCRIPTION
This is a fix for issue #70

Don't try to access the secondary workspace before the view is initialized.
When readonly is true at instantiation we have to wait until after the view is initialized to access it, so skip the fir OnChanges() that runs before the view is initialized and instead call setReadonly() once in ngAfterViewInit() if needed.
