### PR TITLE
more readonly fixes

### DIFF
--- a/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
@@ -269,6 +269,9 @@ export class NgxBlocklyComponent implements OnInit, AfterViewInit, OnChanges, On
         if (this.workspace) {
             Blockly.svgResize(this.workspace);
         }
+        if (this._secondaryWorkspace) {
+            Blockly.svgResize(this._secondaryWorkspace);
+        }
     }
 
     public setReadonly(readOnly: boolean) {

--- a/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
@@ -139,7 +139,8 @@ export class NgxBlocklyComponent implements OnInit, AfterViewInit, OnChanges, On
     }
 
     ngOnChanges(changes: { [propKey: string]: SimpleChange }) {
-        if (changes.readOnly) {
+        //skip this if the change comes before we are initialized
+        if (changes.readOnly && this._secondaryWorkspace) {
             this.setReadonly(changes.readOnly.currentValue);
         }
     }


### PR DESCRIPTION
Fixes mentioned in #72 comments:

Make readonly input work when set to true initially,

Make resize also get the secondary workspace.
