### PR TITLE
Readonly disappears forever if window is resized while not readonly

### DIFF
--- a/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
+++ b/projects/ngx-blockly/src/lib/ngx-blockly/ngx-blockly.component.ts
@@ -291,6 +291,7 @@ export class NgxBlocklyComponent implements OnInit, AfterViewInit, OnChanges, On
                 this._secondaryWorkspace = Blockly.inject(this.secondaryContainer.nativeElement, config);
             }
             Blockly.Xml.clearWorkspaceAndLoadFromXml(Blockly.Xml.textToDom(this.toXml()), this._secondaryWorkspace);
+            Blockly.svgResize(this._secondaryWorkspace);
         } else {
             if (this._secondaryWorkspace) {
                 this.secondaryContainer.nativeElement.classList.add('hidden');


### PR DESCRIPTION
If anything calls Blockly.svgResize while readonly is false you will never see the readonly workspace again unless you call Blockly.svgResize again.  

fixes #78
